### PR TITLE
Compass Fix

### DIFF
--- a/Assets/Design/Resources/Prefabs/UI/Compass.prefab
+++ b/Assets/Design/Resources/Prefabs/UI/Compass.prefab
@@ -293,4 +293,4 @@ MonoBehaviour:
   m_marker: {fileID: 0}
   m_iconPrefab: {fileID: 327608941392648336, guid: bfbfb8665c854ef45a4affd7aa8f0149,
     type: 3}
-  m_maxDistance: 100
+  m_maxDistance: 150

--- a/Assets/Programming/Scripts/Health&Armor/Health.cs
+++ b/Assets/Programming/Scripts/Health&Armor/Health.cs
@@ -23,6 +23,7 @@ public class Health : MonoBehaviour, ISaveable
     public event Action OnDeath;
 
     bool isDead = false;
+    bool isMarkerCreated;
 
     public HealthBarUI healthBar;
 
@@ -39,6 +40,7 @@ public class Health : MonoBehaviour, ISaveable
         if (healthBar != null)
             healthBar.SetMaxHealth(m_MaxHealth);
 
+        isMarkerCreated = false;
 
     }
 
@@ -48,9 +50,10 @@ public class Health : MonoBehaviour, ISaveable
         {
             m_compass = FindObjectOfType<Compass>();
             m_marker = GetComponent<CompassMarkers>();
-            if (gameObject.tag != "Player" && m_marker != null)
+            if (gameObject.tag != "Player" && m_marker != null && isMarkerCreated == false)
             {
                 m_compass.AddMarker(m_marker);
+                isMarkerCreated = true;
             }
         }
         catch

--- a/Assets/Programming/Scripts/Objects/Pickups/AmmoPickup.cs
+++ b/Assets/Programming/Scripts/Objects/Pickups/AmmoPickup.cs
@@ -18,31 +18,18 @@ public class AmmoPickup : MonoBehaviour
 
     public Compass m_compass;
     public CompassMarkers m_marker;
+    
 
     bool isPickedUp;
+    bool isMarkerCreated;
 
     // Start is called before the first frame update
     void Start()
     {
         EventBroker.OnPlayerSpawned += PlayerSpawned;
 
-
-        //if (ammoType == WeaponType.BaseWeapon)
-        //{
-        //    m_marker.m_markerImage = Resources.Load<Image>("Sprites/Icons/Ammo/AMMO_DEFAULT");
-        //}
-        //else if (ammoType == WeaponType.CreatureWeapon)
-        //{
-        //    m_marker.m_markerImage = Resources.Load<Image>("Sprites/Icons/Ammo/AMMO_CREATURE");
-        //}
-        //else
-        //{
-        //    m_marker.m_markerImage = Resources.Load<Image>("Sprites/Icons/Ammo/AMMO_GRENADE");
-        //}
-
-        // m_marker.m_markerImage = FindObjectOfType<Sprite>();
-
         isPickedUp = false;
+        isMarkerCreated = false;
     }
 
     void PlayerSpawned(GameObject playerReference)
@@ -55,8 +42,11 @@ public class AmmoPickup : MonoBehaviour
 
         }
         catch { }
-        if (m_marker != null && m_ammoPickup != null)
+        if (m_marker != null && isMarkerCreated == false)
+        {
             m_compass.AddMarker(m_marker);
+            isMarkerCreated = true;
+        }
 
     }
 

--- a/Assets/Programming/Scripts/Objects/Pickups/HealthPickup.cs
+++ b/Assets/Programming/Scripts/Objects/Pickups/HealthPickup.cs
@@ -13,18 +13,25 @@ public class HealthPickup : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        EventBroker.OnPlayerSpawned += PlayerSpawned;
-     
-        m_marker = GetComponent<CompassMarkers>();
-        m_healthPickup = GetComponent<Pickup>();
+        EventBroker.OnPlayerSpawned += PlayerSpawned;     
+       
 
     }
 
     void PlayerSpawned(GameObject playerRef)
     {
-        m_compass = FindObjectOfType<Compass>();
-        if (m_marker != null)
-        m_compass.AddMarker(m_marker);
+        try
+        {
+            m_healthPickup = GetComponent<Pickup>();
+            m_compass = FindObjectOfType<Compass>();
+            m_marker = GetComponent<CompassMarkers>();
+            if (m_marker != null)
+                m_compass.AddMarker(m_marker);
+        }
+        catch
+        {
+
+        }     
     }
 
     private void OnTriggerEnter(Collider other)

--- a/Assets/Programming/Scripts/UI/Compass.cs
+++ b/Assets/Programming/Scripts/UI/Compass.cs
@@ -19,12 +19,6 @@ public class Compass : MonoBehaviour
     [Tooltip("Maximum distance between player and marker to appear on compass")]
     public float m_maxDistance = 75f;
 
-    //temporary references
-    //public CompassMarkers defaultAmmo;
-    //public CompassMarkers creatureAmmo;
-    //public CompassMarkers grenadeAmmo;
-    //public CompassMarkers drone;
-
     private void Awake()
     {
         m_player = FindObjectOfType<ALTPlayerController>();
@@ -37,12 +31,6 @@ public class Compass : MonoBehaviour
         m_compassDirections.texture = Resources.Load<Texture>("Sprites/HUD/Compass_Directions");
         m_background.sprite = Resources.Load<Sprite>("Sprites/HUD/Compass_Background");
         m_compassUnit = m_compassDirections.rectTransform.rect.width / 360f;
-
-        //temporary references
-        //AddMarker(defaultAmmo);
-        //AddMarker(creatureAmmo);
-        // AddMarker(grenadeAmmo);
-        //AddMarker(drone);
     }
 
     // Update is called once per frame

--- a/Assets/xPersonalx/Vanessa/Compass.prefab
+++ b/Assets/xPersonalx/Vanessa/Compass.prefab
@@ -293,4 +293,4 @@ MonoBehaviour:
   m_marker: {fileID: 0}
   m_iconPrefab: {fileID: 327608941392648336, guid: bfbfb8665c854ef45a4affd7aa8f0149,
     type: 3}
-  m_maxDistance: 100
+  m_maxDistance: 150


### PR DESCRIPTION
Fixed Bug: Compass markers were duplicating for pickups and creating out of bounds markers.
Existing Bug: Compass markers for pickups don't load upon switching scenes unless player runs back into old scene then back into new one again.