### PR TITLE
Upgrade Menu Cursor Bugfix

### DIFF
--- a/Assets/Programming/Scripts/PlayerControllers/ALTPlayerController.cs
+++ b/Assets/Programming/Scripts/PlayerControllers/ALTPlayerController.cs
@@ -88,6 +88,8 @@ public class ALTPlayerController : MonoBehaviour
     public Canvas EquipmentWheel;
     public Canvas WeaponWheel;
 
+    UpgradeMenuUI _upgradeMenu;
+
     public event Action<float> OnTakeDamage;
     public event Action<float> OnHeal;
     public event Action OnDeath;
@@ -226,6 +228,7 @@ public class ALTPlayerController : MonoBehaviour
         _equipmentBelt = FindObjectOfType<EquipmentBelt>();
         _weaponBelt = FindObjectOfType<WeaponBelt>();
         _pauseMenu = FindObjectOfType<PauseMenuUI>();
+        _upgradeMenu = FindObjectOfType<UpgradeMenuUI>();
         isDead = false;
 
         Canvas[] wheelsInScene;
@@ -361,8 +364,8 @@ public class ALTPlayerController : MonoBehaviour
 
     private void PlayerPause()
     {
-        m_ControllerState = ControllerState.Menu;
         _pauseMenu.Pause();
+        _upgradeMenu.Deactivate();
     }
 
     //Death and Respawn functionality -LCC
@@ -784,7 +787,7 @@ public class ALTPlayerController : MonoBehaviour
 
     void HandleEquipmentWheel()
     {
-        if (WeaponWheel.enabled == false && _bIsCredits == false)
+        if (WeaponWheel.enabled == false && _bIsCredits == false && m_ControllerState != ControllerState.Menu)
         {
             if (_bEquipWheel)
             {
@@ -814,7 +817,7 @@ public class ALTPlayerController : MonoBehaviour
 
     public void HandleWeaponWheel()
     {
-        if (EquipmentWheel.enabled == false && _bIsCredits == false)
+        if (EquipmentWheel.enabled == false && _bIsCredits == false && m_ControllerState != ControllerState.Menu)
         {
             if (_bWepWheel)
             {

--- a/Assets/Programming/Scripts/UI/PauseMenuUI.cs
+++ b/Assets/Programming/Scripts/UI/PauseMenuUI.cs
@@ -60,18 +60,21 @@ public class PauseMenuUI : MonoBehaviour
             //pc.enabled = true;
             pc.m_ControllerState = ALTPlayerController.ControllerState.Play;
             PauseMenu.SetActive(false);
+            //Debug.Log("Pause menu state: " + ALTPlayerController.instance.m_ControllerState);
         }
     }
 
     public void Pause()
     {
-        EventSystem.current.SetSelectedGameObject(null);
         if (GameIsPaused)
         {
             Unpause();
         }
-        else
+        else if (ALTPlayerController.instance.m_ControllerState != ALTPlayerController.ControllerState.Menu)
         {
+            EventSystem.current.SetSelectedGameObject(null);
+
+            
             EventSystem.current.SetSelectedGameObject(pauseFirst);
             Time.timeScale = 0f;
             enabled = true;
@@ -82,6 +85,8 @@ public class PauseMenuUI : MonoBehaviour
             ALTPlayerController pc = Player.GetComponent<ALTPlayerController>();
             //pc.enabled = false;
             pc.m_ControllerState = ALTPlayerController.ControllerState.Menu;
+            
+            //Debug.Log("Pause menu state: " + ALTPlayerController.instance.m_ControllerState);
         }
     }
 

--- a/Assets/Programming/Scripts/UI/UpgradeMenuUI.cs
+++ b/Assets/Programming/Scripts/UI/UpgradeMenuUI.cs
@@ -40,10 +40,10 @@ public class UpgradeMenuUI : MonoBehaviour
 
     private void LateUpdate()
     {
-        if (ALTPlayerController.instance.CheckForInteract() && _bInMenu == true)
-        {
-            Deactivate();
-        }
+        //if (ALTPlayerController.instance.CheckForInteract() && ALTPlayerController.instance.m_ControllerState == ALTPlayerController.ControllerState.Menu)
+        //{
+        //    Deactivate();
+        //}
 
         if (DiscriptionText != null)
         {
@@ -73,18 +73,25 @@ public class UpgradeMenuUI : MonoBehaviour
             Cursor.visible = true;
             ALTPlayerController pc = ALTPlayerController.instance;
             pc.m_ControllerState = ALTPlayerController.ControllerState.Menu;
+            //Debug.Log("Upgrade menu state: " + ALTPlayerController.instance.m_ControllerState);
         }
+
     }
 
     public void Deactivate()
     {
-        UpgradeMenu.SetActive(false);
-        _bInMenu = false;
-        Time.timeScale = 1f;
-        Cursor.lockState = CursorLockMode.Locked;
-        Cursor.visible = false;
-        ALTPlayerController pc = ALTPlayerController.instance;
-        pc.m_ControllerState = ALTPlayerController.ControllerState.Play;
+        if (_bInMenu)
+        {
+            UpgradeMenu.SetActive(false);
+            _bInMenu = false;
+            Time.timeScale = 1f;
+            Cursor.lockState = CursorLockMode.Locked;
+            Cursor.visible = false;
+            ALTPlayerController pc = ALTPlayerController.instance;
+            pc.m_ControllerState = ALTPlayerController.ControllerState.Play;
+            //Debug.Log("Upgrade menu state: " + ALTPlayerController.instance.m_ControllerState);
+        }
+
     }
 
     public void InitUpgradeMenu(List<WeaponUpgrade> list)


### PR DESCRIPTION
Changes:
- added menu checks for pause, wheel and upgrade menus to make sure the player is not in a menu before entering
- changed exit button for upgrade menu is now escape